### PR TITLE
Add wrappers scripts to invoke RHEL/Edge CI tests for Automotive

### DIFF
--- a/tests/ostree-ng/Vagrantfile
+++ b/tests/ostree-ng/Vagrantfile
@@ -1,0 +1,21 @@
+Vagrant.configure("2") do |config|
+    config.vagrant.plugins= ["vagrant-env"]
+    config.vm.box = "generic/rhel8"
+    config.env.enable
+    config.vm.provision :shell, path: "setup.sh", 
+        args: "#{ENV['USER']} #{ENV['PASS']}"
+    config.vm.provision :shell do |shell|
+        shell.privileged = true
+        shell.inline = 'echo rebooting'
+        shell.reboot = true
+    end
+    config.vm.provision :shell, path: "ostree-ng.sh", 
+        args: "#{ENV['USER']} #{ENV['PASS']}"
+    config.vm.network "forwarded_port", guest: 9090, host: 9091
+    # enable nested virtualization
+    config.vm.provider :libvirt do |vm|
+         vm.memory = 8192
+         vm.cpus = 4
+         vm.nested = true
+    end
+end

--- a/tests/ostree-ng/ostree-ng.sh
+++ b/tests/ostree-ng/ostree-ng.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Install test dependencies
+dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm; sudo dnf config-manager --set-enabled epel
+dnf install -y ansible jq qemu-img qemu-kvm libvirt-client libvirt-daemon-kvm virt-install git
+
+# Clone the rhel-edge fork where we have a workaround to pull the container locally
+git clone https://github.com/rasibley/rhel-edge.git; cd rhel-edge
+git checkout skip_quay
+chmod 600 key/ostree_key
+./ostree-ng.sh
+
+echo "Done"

--- a/tests/ostree-ng/setup.sh
+++ b/tests/ostree-ng/setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Setup subscription-manager to enable yum repos
+USER=$1
+PASS=$2
+
+subscription-manager register --username $USER --password $PASS
+subscription-manager role --set="Red Hat Enterprise Linux Server"
+subscription-manager service-level --set="Self-Support"
+subscription-manager usage --set="Development/Test"
+subscription-manager attach
+
+# Update vagrant box to 8.4 which is a requirement for iso/container image support
+sudo dnf update -y
+
+echo "Done"

--- a/tests/ostree/Vagrantfile
+++ b/tests/ostree/Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant.configure("2") do |config|
+    config.vagrant.plugins= ["vagrant-env"]
+    config.vm.box = "generic/rhel8"
+    config.env.enable
+    config.vm.provision :shell, path: "ostree.sh", 
+         args: "#{ENV['USER']} #{ENV['PASS']}"
+    config.vm.network "forwarded_port", guest: 9090, host: 9091
+    # enable nested virtualization
+    config.vm.provider :libvirt do |vm|
+         vm.memory = 8192
+         vm.cpus = 4
+         vm.nested = true
+    end
+end

--- a/tests/ostree/ostree.sh
+++ b/tests/ostree/ostree.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+USER=$1
+PASS=$2
+
+# Setup subscription-manager to enable yum repos
+subscription-manager register --username $USER --password $PASS
+subscription-manager role --set="Red Hat Enterprise Linux Server"
+subscription-manager service-level --set="Self-Support"
+subscription-manager usage --set="Development/Test"
+subscription-manager attach
+
+# Install test dependencies
+dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm; sudo dnf config-manager --set-enabled epel
+dnf install -y ansible jq qemu-img qemu-kvm libvirt-client libvirt-daemon-kvm virt-install git
+git clone https://github.com/virt-s1/rhel-edge.git; cd rhel-edge
+chmod 600 key/ostree_key
+./ostree.sh
+
+echo "Done"


### PR DESCRIPTION
Add wrapper scripts to be invoked inside a Vagrant box, this will
be used initially for briningup while we work towards onboarding and
adapting the existing RHEL/Edge CI tests for Automotive CI