### PR TITLE
add OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+# CODE OWNERS
+
+reviewers:
+- HubertStefanski
+- JaneSoo
+- lioramilbaum
+- RajeshKumarSrivastava


### PR DESCRIPTION
- Adds OWNERS: we should keep them defined here to avoid hardcoding these values into Dover, we can also update (add/remove) people from the reviewer poll whenever, without the need to interfere with a running Dover instance