### PR TITLE
CI improvements

### DIFF
--- a/tests/ci/clean_up.sh
+++ b/tests/ci/clean_up.sh
@@ -9,7 +9,8 @@ TEMPDIR=${TEMPDIR:-}
 HTTPD_PATH=${HTTPD_PATH:-}
 
 greenprint "🧼 Cleaning up: start"
-virsh destroy "${IMAGE_KEY}"
+# Remove stop and remove the VM
+virsh destroy "${IMAGE_KEY}" || true
 virsh undefine "${IMAGE_KEY}" --nvram
 #TODO: Remove the resulted VM until we find a way to save it at S3
 virsh vol-delete --pool images "${IMAGE_KEY}".qcow2

--- a/tests/ci/clean_up.sh
+++ b/tests/ci/clean_up.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+# Restore the *-release files
+cp -fv "${TMPCI_DIR}"/os-release /etc/
+cp -fv "${TMPCI_DIR}"/redhat-release /etc/
+
 source /tmp/.env
 
 ID=${ID:-}
@@ -26,9 +30,6 @@ fi
 rm -rf "$TEMPDIR"
 # Stop httpd
 systemctl disable httpd --now
-# Restore the *-release files
-cp -fv "${TMPCI_DIR}"/os-release /etc/
-cp -fv "${TMPCI_DIR}"/redhat-release /etc/
 
 # Remove temporary CI files
 rm -fvr "${TMPCI_DIR}"

--- a/tests/ci/image-build.fmf
+++ b/tests/ci/image-build.fmf
@@ -15,7 +15,9 @@ environment:
 prepare:
   - name: Enable EPEL repo
     how: shell
-    script: dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    script:
+      - dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+      - dnf config-manager --set-enabled epel
   - name: Install dependencies
     how: install
     package:

--- a/tests/ci/image-build.fmf
+++ b/tests/ci/image-build.fmf
@@ -12,6 +12,7 @@ environment:
   KS_FILE: "tests/ci/files/ks.cfg"
   NET_CONFIG: "tests/ci/files/integration-net.xml"
   SSH_KEY: "tests/ci/files/tempkey"
+  TMPCI_DIR: "/tmp/ci"
 prepare:
   - name: Enable EPEL repo
     how: shell

--- a/tests/ci/install-vm.sh
+++ b/tests/ci/install-vm.sh
@@ -30,7 +30,7 @@ restorecon -Rv /var/lib/libvirt/images/
 # Create qcow2 file for virt install.
 greenprint "Create qcow2 file for virt install"
 LIBVIRT_IMAGE_PATH=/var/lib/libvirt/images/${IMAGE_KEY}.qcow2
-qemu-img create -f qcow2 "${LIBVIRT_IMAGE_PATH}" 20G
+qemu-img create -f qcow2 "${LIBVIRT_IMAGE_PATH}" 6G
 
 # Generate a temporary SSH key
 ssh-keygen -t ecdsa -f "$SSH_KEY" -q -N ""

--- a/tests/ci/setup.sh
+++ b/tests/ci/setup.sh
@@ -35,7 +35,7 @@ echo "osbuild version"
 rpm -qa | grep -i osbuild
 
 # Create directory for CI files
-TMPCI_DIR="/tmp/ci"
+TMPCI_DIR=${TMPCI_DIR:"/tmp/ci"}
 if [ -d "${TMPCI_DIR}" ]; then
     rm -fr "${TMPCI_DIR}"
 fi


### PR DESCRIPTION
Some improvements to make the scripts more robust.

* Make sure epel is enabled.
* Reduce the qcow2 file size. The file was 20 Gb and the installation uses ~ 4Gb. 6 Gb should be enough for any extra space needed and this will reduce considerably the artifacts size.
* Make sure the `os-release` and `redhat-release` files are restored even if other things fail.