### PR TITLE
Headless testing

### DIFF
--- a/tests/ci/files/blueprint.toml
+++ b/tests/ci/files/blueprint.toml
@@ -213,6 +213,10 @@ name = "efibootmgr"
 version = "*"
 
 [[packages]]
+name = "xorg-x11-drv-dummy"
+version = "*"
+
+[[packages]]
 name = "xorg-x11-server-Xwayland"
 version = "*"
 

--- a/tests/ci/files/ks_tmpl.cfg
+++ b/tests/ci/files/ks_tmpl.cfg
@@ -44,6 +44,36 @@ EOF
 # Ensure we have no file system permission error
 chown edge:edge -R /home/edge
 
+# Xorg
+cat > /etc/X11/xorg.conf << EOF
+Section "Device"
+    Identifier "Configured Video Device"
+    Driver "dummy"
+    #VideoRam 4096000
+    #VideoRam 256000
+    VideoRam 16384
+EndSection
+
+Section "Monitor"
+    Identifier "Configured Monitor"
+    HorizSync 5.0 - 1000.0
+    VertRefresh 5.0 - 200.0
+    Modeline "1600x900" 33.92 1600 1632 1760 1792 900 921 924 946
+EndSection
+
+Section "Screen"
+    Identifier "Default Screen"
+    Monitor "Configured Monitor"
+    Device "Configured Video Device"
+    DefaultDepth 24
+    SubSection "Display"
+        Viewport 0 0
+        Depth 24
+        Virtual 1600 900
+    EndSubSection
+EndSection
+EOF
+
 # Automatically log in as 'edge'
 cat > /etc/gdm/custom.conf << EOF
 ## custom.conf

--- a/tests/ci/test-vm.sh
+++ b/tests/ci/test-vm.sh
@@ -54,6 +54,33 @@ assert_package_installed () {
 }
 
 
+# Tests definitions
+test_is_centos () {
+    greenprint "Checking if the OS running is CentOS"
+    OS_ID=$(ssh_run "source /etc/os-release ; echo \$ID")
+
+    assert "$OS_ID" "centos"
+}
+
+test_neptune_is_installed () {
+    greenprint "Checking if the Neptune package is installed"
+
+    assert_package_installed "neptune3-ui"
+}
+
+test_gnome_is_running () {
+    greenprint "Checking if GNOME is running"
+
+    assert_process_running "/usr/bin/gnome-shell"
+}
+
+test_neptune_is_running () {
+    greenprint "Checking if Neptune is running"
+
+    assert_process_running "neptune3-ui"
+}
+
+
 # Start VM.
 greenprint "Start VM"
 virsh start "${IMAGE_KEY}"
@@ -68,8 +95,17 @@ for LOOP_COUNTER in $(seq 0 30); do
     sleep 10
 done
 
-# Check image installation result
-check_result
 
-greenprint "Here is the resulted VM: $LIBVIRT_IMAGE_PATH"
+# Tests
+greenprint "🛃 Tests 🛃"
+
+test_is_centos
+
+test_neptune_is_installed
+
+# Wait a bit for the X and the app to start
+sleep 30
+test_gnome_is_running
+
+test_neptune_is_running
 

--- a/tests/ci/test-vm.sh
+++ b/tests/ci/test-vm.sh
@@ -8,30 +8,51 @@ GUEST_ADDRESS=${GUEST_ADDRESS:-}
 SSH_KEY=${SSH_KEY:-}
 
 # SSH setup.
-SSH_OPTIONS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5)
+SSH_OPTIONS=(-q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -i ${SSH_KEY} admin@${GUEST_ADDRESS})
+
+ssh_run () {
+    cmd="$*"
+    ssh "${SSH_OPTIONS[@]}" "/bin/bash -c '${cmd}'"
+}
 
 # Wait for the ssh server up to be.
 wait_for_ssh_up () {
-    SSH_STATUS=$(ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@"${1}" '/bin/bash -c "echo -n READY"')
-    if [[ $SSH_STATUS == READY ]]; then
+    SSH_STATUS=$(ssh_run "echo -n READY")
+    if [[ "$SSH_STATUS" == READY ]]; then
         echo 1
     else
         echo 0
     fi
 }
 
-# Test result checking
-check_result () {
-    greenprint "Checking for test result"
-    if [[ $RESULTS == 1 ]]; then
-	greenprint "Cheking OS version"
-	ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@"${GUEST_ADDRESS}" '/bin/bash -c "cat /etc/redhat-release"'
+# Helper function for the tests
+assert () {
+    local actual="$1"
+    local expected="$2"
+
+    if [[ "$actual" == "$expected" ]]; then
         greenprint "💚 Success"
     else
         greenprint "❌ Failed"
+        ssh_run "free -h ; df -h ; ps aux | grep edge ; journalctl -p err -n 100"
         exit 1
     fi
 }
+
+assert_process_running () {
+    process="$1"
+    processes=$(ssh_run "ps -u edge a | grep -v grep | grep -c ${process}") || true
+
+    assert "$processes" "1"
+}
+
+assert_package_installed () {
+    package="$1"
+    installed=$(ssh_run "rpm --quiet -q ${package} ; echo \$?")
+
+    assert "$installed" "0"
+}
+
 
 # Start VM.
 greenprint "Start VM"
@@ -41,8 +62,7 @@ virsh start "${IMAGE_KEY}"
 greenprint "🛃 Checking for SSH is ready to go"
 for LOOP_COUNTER in $(seq 0 30); do
     RESULTS="$(wait_for_ssh_up $GUEST_ADDRESS)"
-    if [[ $RESULTS == 1 ]]; then
-        echo "SSH is ready now! 🥳"
+    if [[ "$RESULTS" == 1 ]]; then
         break
     fi
     sleep 10

--- a/tests/ci/test-vm.sh
+++ b/tests/ci/test-vm.sh
@@ -107,5 +107,8 @@ test_neptune_is_installed
 sleep 30
 test_gnome_is_running
 
-test_neptune_is_running
+# FIXME: Neptune app is starting but crashing. Jira issue: VROOM-418
+# Uncomment this tests when the Neptune app stops crashing, to avoid
+# false negatives to other PRs.
+#test_neptune_is_running
 

--- a/tests/ci/test-vm.sh
+++ b/tests/ci/test-vm.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 source /tmp/.env
 
 IMAGE_KEY=${IMAGE_KEY:-}
-LIBVIRT_IMAGE_PATH=${LIBVIRT_IMAGE_PATH:-}
 GUEST_ADDRESS=${GUEST_ADDRESS:-}
 SSH_KEY=${SSH_KEY:-}
 


### PR DESCRIPTION
Add some packages and configurations to the image, so it can run in headless (with dummy X server in a non-graphical VM).
This is mandatory to be able to run and test any graphical app in a CI/CD setup.

Also, this add two smoke test for testing that the current demo app (Netptune) is running.

NOTE: Right now the app is crashing at start, so the test if failing, but the fake Xorg server is working.