### PR TITLE
Increase the timeout to avoid canceling the image building

### DIFF
--- a/.github/workflows/ateam.yml
+++ b/.github/workflows/ateam.yml
@@ -15,7 +15,7 @@ jobs:
     concurrency: single
     runs-on: ubuntu-latest
     container: quay.io/testing-farm/tmt:1.6.0
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
At the last pipeline runs, the Image Builder has taken longer for creating the OSTree Commit, so it has expired the timeout.

It might be due network issue, but it's making the pipeline break without apparent reason.
This hotfix tries to check if there's actually an issue and let the PR create successful pipelines.