### PR TITLE
Add post run cleanup

### DIFF
--- a/.github/workflows/ateam.yml
+++ b/.github/workflows/ateam.yml
@@ -30,3 +30,11 @@ jobs:
         run: |
             tmt run -vvv --all provision --how connect --guest ${{ secrets.HOST }} --key ~/.ssh/id_rsa
         shell: bash
+
+      - name: Clean and fix
+        # This should run even if the job is canceled
+        if: ${{ always() }}
+        run: |
+          scp -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa tests/ci/fix_baremetal.sh ${{ secrets.HOST }}:
+          ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa ${{ secrets.HOST }} ./fix_baremetal.sh
+        shell: bash

--- a/tests/ci/fix_baremetal.sh
+++ b/tests/ci/fix_baremetal.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+echo "Fixing *-release files"
+cat > /etc/os-release <<EOF
+NAME="CentOS Stream"
+VERSION="8"
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="8"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="CentOS Stream 8"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:centos:centos:8"
+HOME_URL="https://centos.org/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 8"
+REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"
+EOF
+
+cat > /etc/redhat-release <<EOF
+CentOS Stream release 8
+EOF
+
+echo "Remove ramaining composes"
+composes=$(composer-cli compose list | awk '{ print $1 }')
+for compose in $composes; do
+    composer-cli compose cancel "$compose"
+    composer-cli compose delete "$compose"
+done
+
+echo "Remove the old sources"
+composer-cli sources delete copr_neptune
+
+echo "Stop and undefine the remaining VMs"
+vms=$(virsh list --all --name)
+for vm in $vms; do
+    virsh destroy "${vm}"
+    virsh undefine "${vm}" --nvram
+done
+
+echo "Remove all the VM images"
+for image in $(ls /var/lib/libvirt/images/); do
+    virsh vol-delete --pool images "${image}"
+done
+
+echo "Remove the virtual network"
+if virsh net-info integration > /dev/null 2>&1; then
+    virsh net-destroy integration
+    virsh net-undefine integration
+fi
+
+echo "Clean httpd directory"
+rm -fr /var/www/html/{compose.json,ks.cfg,repo}
+

--- a/tests/ci/setup.sh
+++ b/tests/ci/setup.sh
@@ -35,7 +35,7 @@ echo "osbuild version"
 rpm -qa | grep -i osbuild
 
 # Create directory for CI files
-TMPCI_DIR=${TMPCI_DIR:"/tmp/ci"}
+TMPCI_DIR=${TMPCI_DIR:-"/tmp/ci"}
 if [ -d "${TMPCI_DIR}" ]; then
     rm -fr "${TMPCI_DIR}"
 fi


### PR DESCRIPTION
Add script to run after the workflow finish
It will run even if the jobs get canceled and it'll clean up all the left overs from the pipeline run.
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always

This should solve the issues we're having when a jobs get canceled or miss something during the cleaning up.