### PR TITLE
aws cp to s3: suppress upload progress

### DIFF
--- a/tests/ci/sync-to-aws.sh
+++ b/tests/ci/sync-to-aws.sh
@@ -13,7 +13,7 @@ $AWS_CLI configure set default.region "$AWS_REGION"
 $AWS_CLI configure set default.output json
 
 echo "[+] Uploading raw image to 's3://${S3_BUCKET_NAME}/${IMAGE_KEY}.raw"
-$AWS_CLI s3 cp ${DOWNLOAD_DIRECTORY}/${IMAGE_KEY}.raw s3://${S3_BUCKET_NAME}
+$AWS_CLI s3 cp ${DOWNLOAD_DIRECTORY}/${IMAGE_KEY}.raw s3://${S3_BUCKET_NAME} --only-show-errors
 
 echo "[+] Import snapshot to EC2"
 IMPORT_SNAPSHOT_ID=$($AWS_CLI ec2 import-snapshot --disk-container Format=raw,UserBucket="{S3Bucket=${S3_BUCKET_NAME},S3Key=${IMAGE_KEY}.raw}" | jq -r .ImportTaskId)


### PR DESCRIPTION
Uploading the image to S3 prints out THOUSANDS of lines like these into the CI logging and makes the log file cumbersome and hard to read or even load.
```
2021-07-28T10:33:26.1797073Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1797875Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1798658Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1799443Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1800340Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1801176Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1803073Z                     Completed 2.6 GiB/6.0 GiB (223.0 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1804005Z                     Completed 2.6 GiB/6.0 GiB (223.0 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1804882Z                     Completed 2.6 GiB/6.0 GiB (223.0 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1806050Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1806835Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1807626Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1808408Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1809189Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1810196Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
2021-07-28T10:33:26.1811078Z                     Completed 2.6 GiB/6.0 GiB (223.1 MiB/s) with 1 file(s) remaining   
```

This PR suppresses these lines and only prints errors, if there are any.