### PR TITLE
Upload the generated ssh key for the VM to S3

### DIFF
--- a/tests/ci/sync-to-aws.sh
+++ b/tests/ci/sync-to-aws.sh
@@ -16,6 +16,13 @@ echo "[+] Configure AWS settings"
 $AWS_CLI configure set default.region "$AWS_REGION"
 $AWS_CLI configure set default.output json
 
+if [ ! -r "${SSH_KEY}" ]; then
+    echo "Error: the file ${SSH_KEY} doesn't exist"
+    exit 1
+fi
+echo "[+] Uploading ssh key for the image to 's3://${S3_BUCKET_NAME}/${IMAGE_KEY}.key"
+$AWS_CLI s3 cp ${SSH_KEY} s3://${S3_BUCKET_NAME}/${IMAGE_KEY}.key --only-show-errors
+
 if [ ! -r "${DOWNLOAD_DIRECTORY}/${IMAGE_KEY}.raw" ]; then
     echo "Error: the file ${DOWNLOAD_DIRECTORY}/${IMAGE_KEY}.raw doesn't exist"
     exit 1


### PR DESCRIPTION
We generate a new pair of ssh keys per each build. We need to store the ssh key to be able to access to the image later.